### PR TITLE
Add "The Bitter Lesson" to reading list

### DIFF
--- a/content/reading/_index.md
+++ b/content/reading/_index.md
@@ -31,6 +31,7 @@ Some of my favorites.
 - Self Reliance, by Ralph Waldo Emerson
 
 ## Blogs/Articles
+- [The Bitter Lesson](https://www.cs.utexas.edu/~eunsol/courses/data/bitter_lesson.pdf)
 - [The Bet On Juniors Just Got Better](https://tidyfirst.substack.com/p/the-bet-on-juniors-just-got-better)
 - [My productivity app is a never-ending .txt file](https://jeffhuang.com/productivity_text_file/)
 - [If You're Going to Vibe Code, Why Not Do It in C?](https://stephenramsay.net/posts/vibe-coding.html)


### PR DESCRIPTION
This PR adds "The Bitter Lesson" by Richard Sutton to the top of the Blogs/Articles section in the reading list.

The paper is a seminal essay on AI research that discusses how general methods leveraging computation are ultimately more powerful than methods that leverage human knowledge.

**Link:** https://www.cs.utexas.edu/~eunsol/courses/data/bitter_lesson.pdf